### PR TITLE
fix: Improve resizing with tiling window managers

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -118,7 +118,11 @@ export const createWindow = async () => {
         menu.popup({ window: popup });
     });
 
-    window.on("resize", resizeServices);
+    // Use `setImmediate` here to fix a bug with i3 and other Window-Managers
+    // not resizing the Service View correctly. For some reasons the old bounds
+    // are returned, if `getContentBounds` is called on the same event loop tick
+    // Also see: https://github.com/teruncius/erpel/pull/2
+    window.on("resize", () => setImmediate(resizeServices));
     window.on("show", window.focus);
 
     function createViewForService(service: Service) {


### PR DESCRIPTION
## Problem

Add setImmediate wrapper to getContentBounds() call in resize event handler to ensure bounds are read after Electron's internal state is fully updated, preventing race condition with i3's window resize events.

### Before

https://github.com/user-attachments/assets/1b1b6588-710a-4f02-ad1c-73525a22d1f8

### After

https://github.com/user-attachments/assets/100c97b4-9066-47b6-8ff1-793c108e3db5




