### PR TITLE
feat: allow uploading custom icons for website services

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://images.unsplash.com/;"
+            content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://images.unsplash.com/;"
         />
         <title>erpel</title>
     </head>

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -45,6 +45,10 @@ const ICONS: Record<string, string> = {
 };
 
 export function IconIdToUrl(id: string): string {
+    if (!id) return "";
+    if (id.startsWith("data:") || id.startsWith("http")) {
+        return id;
+    }
     return ICONS[id] || "";
 }
 
@@ -269,7 +273,7 @@ export const DEFAULT_SERVICE_TEMPLATES: ServiceTemplate[] = [
         },
         icon: {
             copyOnCreate: false,
-            customizable: false,
+            customizable: true,
             default: "173773cb-72de-429f-94db-d382613f436d",
         },
         id: "5f8c2fe3-5be6-4f1c-a58d-e7e746db2b0a",

--- a/src/ui/components/settings/service-form.test.tsx
+++ b/src/ui/components/settings/service-form.test.tsx
@@ -13,6 +13,13 @@ vi.mock("../../icon", () => ({
     ),
 }));
 
+// Mock ServiceIcon component
+vi.mock("./service-icon", () => ({
+    ServiceIcon: ({ icon, name, size }: { icon: string; name: string; size: number }) => (
+        <img alt={name} data-icon={icon} data-size={size} />
+    ),
+}));
+
 // Mock the store
 const mockReplace = vi.fn();
 vi.mock("../../store/store", () => ({
@@ -284,6 +291,125 @@ describe("ServiceForm", () => {
 
             const darkModeCheckbox = screen.getByLabelText(/dark mode/i);
             expect(darkModeCheckbox).toBeInTheDocument();
+        });
+    });
+
+    describe("Conditional Rendering - Icon Field", () => {
+        it("renders icon upload when customizable", () => {
+            const service = createMockService({
+                template: {
+                    ...createMockService().template,
+                    icon: {
+                        copyOnCreate: false,
+                        customizable: true,
+                        default: "test-icon",
+                    },
+                },
+            });
+
+            render(<ServiceForm service={service} />);
+
+            expect(screen.getByLabelText(/icon/i)).toBeInTheDocument();
+        });
+
+        it("does not render icon upload when not customizable", () => {
+            const service = createMockService({
+                template: {
+                    ...createMockService().template,
+                    icon: {
+                        copyOnCreate: false,
+                        customizable: false,
+                        default: "test-icon",
+                    },
+                },
+            });
+
+            render(<ServiceForm service={service} />);
+
+            expect(screen.queryByLabelText(/upload icon/i)).not.toBeInTheDocument();
+        });
+
+        it("shows icon preview using service icon value", () => {
+            const service = createMockService({
+                icon: "data:image/png;base64,abc123",
+                template: {
+                    ...createMockService().template,
+                    icon: {
+                        copyOnCreate: false,
+                        customizable: true,
+                        default: "test-icon",
+                    },
+                },
+            });
+
+            render(<ServiceForm service={service} />);
+
+            const preview = screen.getByAltText("icon preview");
+            expect(preview).toHaveAttribute("data-icon", "data:image/png;base64,abc123");
+        });
+
+        it("falls back to template default icon when service icon is null", () => {
+            const service = createMockService({
+                icon: null,
+                template: {
+                    ...createMockService().template,
+                    icon: {
+                        copyOnCreate: false,
+                        customizable: true,
+                        default: "default-icon-uuid",
+                    },
+                },
+            });
+
+            render(<ServiceForm service={service} />);
+
+            const preview = screen.getByAltText("icon preview");
+            expect(preview).toHaveAttribute("data-icon", "default-icon-uuid");
+        });
+
+        it("updates icon preview after file upload", async () => {
+            const dataUrl = "data:image/png;base64,iVBORw0KGgo=";
+            let fireLoad: (() => void) | undefined;
+
+            class MockFileReader {
+                onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+                result: string = dataUrl;
+                readAsDataURL() {
+                    const self = this;
+                    fireLoad = () => {
+                        self.onload?.({ target: self } as unknown as ProgressEvent<FileReader>);
+                    };
+                }
+            }
+
+            vi.stubGlobal("FileReader", MockFileReader);
+
+            const service = createMockService({
+                icon: null,
+                template: {
+                    ...createMockService().template,
+                    icon: {
+                        copyOnCreate: false,
+                        customizable: true,
+                        default: "default-icon-uuid",
+                    },
+                },
+            });
+
+            render(<ServiceForm service={service} />);
+
+            const fileInput = screen.getByLabelText(/upload icon/i);
+            const file = new File(["png-content"], "favicon.png", { type: "image/png" });
+            await userEvent.setup().upload(fileInput, file);
+
+            fireLoad?.();
+
+            await waitFor(() => {
+                const preview = screen.getByAltText("icon preview");
+                expect(preview).toHaveAttribute("data-icon", dataUrl);
+            });
+
+            vi.unstubAllGlobals();
         });
     });
 

--- a/src/ui/components/settings/service-form.tsx
+++ b/src/ui/components/settings/service-form.tsx
@@ -8,9 +8,11 @@ import { ThemedButton } from "@erpel/ui/components/theme/button";
 import { ThemedCheckbox } from "@erpel/ui/components/theme/checkbox";
 import { ThemedInput } from "@erpel/ui/components/theme/input";
 import { useStore } from "@erpel/ui/store/store";
+import { ServiceIcon } from "./service-icon";
 
 export interface Values {
     darkMode: boolean | null;
+    icon: null | string;
     name: null | string;
     url: null | string;
 }
@@ -20,8 +22,11 @@ interface ServiceFormProps {
 }
 
 export function ServiceForm(props: ServiceFormProps) {
-    const { control, handleSubmit, register } = useForm<Values>({ defaultValues: props.service });
+    const { control, handleSubmit, register, setValue, watch } = useForm<Values>({ defaultValues: props.service });
     const { replace } = useStore();
+
+    const currentIcon = watch("icon");
+    const iconPreview = currentIcon || props.service.template.icon.default;
 
     const onSubmit: SubmitHandler<Values> = useCallback(
         (data) => {
@@ -34,8 +39,41 @@ export function ServiceForm(props: ServiceFormProps) {
         return value !== null && value.trim().length > 0 ? value : null;
     }, []);
 
+    const handleIconChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                const dataUrl = event.target?.result as string;
+                setValue("icon", dataUrl);
+            };
+            reader.readAsDataURL(file);
+        },
+        [setValue]
+    );
+
     return (
         <Form onSubmit={handleSubmit(onSubmit)}>
+            {props.service.template.icon.customizable && (
+                <Fieldset>
+                    <FieldsetHeading>Icon</FieldsetHeading>
+                    <IconUploadRow>
+                        <ServiceIcon icon={iconPreview} name="icon preview" size={48} />
+                        <IconUploadLabel htmlFor={`${props.service.id}::icon`}>
+                            <Icon name="folder-upload" size={16} />
+                            Upload Icon
+                            <HiddenFileInput
+                                accept="image/*"
+                                id={`${props.service.id}::icon`}
+                                onChange={handleIconChange}
+                                type="file"
+                            />
+                        </IconUploadLabel>
+                    </IconUploadRow>
+                </Fieldset>
+            )}
             {props.service.template.name.customizable && (
                 <Fieldset>
                     <Label htmlFor={`${props.service.id}::name`}>Name</Label>
@@ -112,8 +150,40 @@ const Label = styled.label`
     cursor: pointer;
 `;
 
+const FieldsetHeading = styled.span`
+    cursor: default;
+`;
+
 const Buttons = styled.div`
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+`;
+
+const IconUploadRow = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+`;
+
+const IconUploadLabel = styled.label`
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    border-radius: 0.25rem;
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    font-size: 0.875rem;
+    user-select: none;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.25);
+    }
+`;
+
+const HiddenFileInput = styled.input`
+    display: none;
 `;


### PR DESCRIPTION
Closes #5. Users can now upload a custom favicon/icon for any service with a customizable icon (currently the Website template). The icon is stored as a base64 data URL in the config. The CSP was updated to allow data: URIs in img-src so uploaded icons render correctly.

<img width="1139" height="681" alt="image" src="https://github.com/user-attachments/assets/59ac62ec-eab3-4f1a-8d67-5410ff065224" />
